### PR TITLE
fix: Resolve formula rendering and model output formatting

### DIFF
--- a/resophy/tools/agent_tools/summary_pdf.py
+++ b/resophy/tools/agent_tools/summary_pdf.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import threading
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List
@@ -214,7 +215,7 @@ INPUT: <MARKDOWN>"""
         )
 
         result_content = chat_completion.choices[0].message.content
-
+        result_content = re.sub(r"<think>[\s\S]*?</think>", "", result_content, flags=re.IGNORECASE)
         result_file = os.path.join(pdf_output_dir, "result.md")
         with open(result_file, "w", encoding="utf-8") as f:
             f.write(result_content)

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8582,7 +8582,7 @@ async function viewAnalysisResult(paperId, event) {
             return match;
         });
 
-        // 渲染 markdown
+        // 渲染 markdown（保护公式片段，避免被 marked 改写）
         if (typeof marked !== 'undefined') {
             marked.setOptions({
                 breaks: true,
@@ -8599,7 +8599,21 @@ async function viewAnalysisResult(paperId, event) {
 
         let htmlContent = '';
         if (typeof marked !== 'undefined') {
-            htmlContent = marked.parse(markdownContent);
+            const preserved = [];
+            const mdPreserved = markdownContent
+                .replace(/\$\$([\s\S]*?)\$\$/g, function(match) {
+                    const id = preserved.length;
+                    preserved.push(match);
+                    return `@@MJX_BLOCK_${id}@@`;
+                })
+                .replace(/(?<!\\)\$([^\n$]+)\$/g, function(match) {
+                    const id = preserved.length;
+                    preserved.push(match);
+                    return `@@MJX_INLINE_${id}@@`;
+                });
+            htmlContent = marked.parse(mdPreserved).replace(/@@MJX_(BLOCK|INLINE)_(\d+)@@/g, function(_, __, idx) {
+                return preserved[Number(idx)];
+            });
         } else {
             htmlContent = `<pre style="white-space: pre-wrap;">${escapeHtml(markdownContent)}</pre>`;
         }
@@ -8622,6 +8636,30 @@ async function viewAnalysisResult(paperId, event) {
         // 应用样式（若需要）
         if (typeof applyMarkdownStyles === 'function') {
             applyMarkdownStyles();
+        }
+
+        // 数学公式排版（MathJax）
+        const el = paperInfoEl.querySelector('.paper-info-content');
+        if (window.MathJax && MathJax.startup && MathJax.startup.promise) {
+            MathJax.startup.promise.then(() => {
+                if (MathJax.typesetPromise) {
+                    MathJax.typesetPromise([el]);
+                } else if (MathJax.typeset) {
+                    MathJax.typeset([el]);
+                }
+            });
+        } else if (window.MathJax) {
+            if (MathJax.typesetPromise) {
+                MathJax.typesetPromise([el]);
+            } else if (MathJax.typeset) {
+                MathJax.typeset([el]);
+            }
+        } else {
+            setTimeout(() => {
+                if (window.MathJax && MathJax.typesetPromise) {
+                    MathJax.typesetPromise([el]);
+                }
+            }, 500);
         }
     } catch (e) {
         console.error('获取结果失败:', e);

--- a/templates/analysis_viewer.html
+++ b/templates/analysis_viewer.html
@@ -9,6 +9,19 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>
+        window.MathJax = {
+            tex: {
+                inlineMath: [["$", "$"], ["\\(", "\\)"]],
+                displayMath: [["$$", "$$"], ["\\[", "\\]"]]
+            },
+            options: {
+                skipHtmlTags: ["script", "noscript", "style", "textarea", "pre"],
+                processHtmlClass: "markdown-viewer"
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
     <style>
         * { 
             box-sizing: border-box; 
@@ -359,10 +372,45 @@
                         return code;
                     }
                 });
-                const html = marked.parse(mdText);
-                document.getElementById('md').innerHTML = html;
+                const preserved = [];
+                const mdPreserved = mdText.replace(/\$\$([\s\S]*?)\$\$/g, function(match) {
+                    const id = preserved.length;
+                    preserved.push(match);
+                    return `@@MJX_BLOCK_${id}@@`;
+                }).replace(/(?<!\\)\$([^\n$]+)\$/g, function(match) {
+                    const id = preserved.length;
+                    preserved.push(match);
+                    return `@@MJX_INLINE_${id}@@`;
+                });
+                let html = marked.parse(mdPreserved);
+                html = html.replace(/@@MJX_(BLOCK|INLINE)_(\d+)@@/g, function(_, __, idx) {
+                    return preserved[Number(idx)];
+                });
+                const el = document.getElementById('md');
+                el.innerHTML = html;
                 if (typeof hljs !== 'undefined') {
                     document.querySelectorAll('pre code').forEach((block) => hljs.highlightElement(block));
+                }
+                if (window.MathJax && MathJax.startup && MathJax.startup.promise) {
+                    MathJax.startup.promise.then(() => {
+                        if (MathJax.typesetPromise) {
+                            MathJax.typesetPromise([el]);
+                        } else if (MathJax.typeset) {
+                            MathJax.typeset([el]);
+                        }
+                    });
+                } else if (window.MathJax) {
+                    if (MathJax.typesetPromise) {
+                        MathJax.typesetPromise([el]);
+                    } else if (MathJax.typeset) {
+                        MathJax.typeset([el]);
+                    }
+                } else {
+                    setTimeout(() => {
+                        if (window.MathJax && MathJax.typesetPromise) {
+                            MathJax.typesetPromise([el]);
+                        }
+                    }, 500);
                 }
             } else {
                 document.getElementById('md').innerHTML = `<pre style="white-space: pre-wrap;">${mdText}</pre>`;

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,19 @@
     <!-- Highlight.js (CDN) 用于代码高亮 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>
+        window.MathJax = {
+            tex: {
+                inlineMath: [["$", "$"], ["\\(", "\\)"]],
+                displayMath: [["$$", "$$"], ["\\[", "\\]"]]
+            },
+            options: {
+                skipHtmlTags: ["script", "noscript", "style", "textarea", "pre"],
+                processHtmlClass: "markdown-viewer"
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 </head>
 <body>
     <!-- 导航栏 -->


### PR DESCRIPTION
修复点一：数学公式渲染错误现象/问题描述：页面上的数学表达式（如使用 MathJax 或 KaTeX 的 $E=mc^2$）无法被渲染库正确处理，导致用户看到的是未格式化的 LaTeX 代码，而不是漂亮的公式。

修复：
- 在全屏页和首页预览中引入并配置 MathJax，同时在渲染后主动触发排版，确保 $$...$$ 和 $...$ 的公式被正确显示。
- 在 Markdown 渲染前用占位符保护公式，避免 marked 破坏公式内容，渲染完成后恢复公式再由 MathJax处理。

修复点二：CoT 模型在生成结果时，会输出内部的思考过程，并用 <think>...</think> 标签包裹。最终展示给用户的步骤中污染了markdown文件的结果。

修复：
- 使用re匹配<think>...</think> 标签内容并清除。
