### PR TITLE
[Update] Remove max-model-len config

### DIFF
--- a/docs/installation_en.md
+++ b/docs/installation_en.md
@@ -265,8 +265,6 @@ vllm serve ai_server/Qwen3-4B-Instruct-2507 \
   --api-key token-abc123 \
   --host 0.0.0.0 \
   --port 6002 \
-  --max-model-len 32768 \
-  --gpu-memory-utilization 0.7
 ```
 
 **Method 2: Use Remote LLM API**

--- a/docs/installation_zh.md
+++ b/docs/installation_zh.md
@@ -264,8 +264,6 @@ vllm serve ai_server/Qwen3-4B-Instruct-2507 \
   --api-key token-abc123 \
   --host 0.0.0.0 \
   --port 6002 \
-  --max-model-len 32768 \
-  --gpu-memory-utilization 0.7
 ```
 
 **方式二：使用远程 LLM API**

--- a/resophy/routes/basic_routes/update_from_url_route.py
+++ b/resophy/routes/basic_routes/update_from_url_route.py
@@ -56,21 +56,31 @@ def _extract_arxiv_id_from_url(url: str) -> Optional[str]:
 
 
 def _download_arxiv_pdf(arxiv_id: str) -> Optional[tuple[bytes, str]]:
-    pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
-    try:
-        print(f"正在从 arXiv 下载 PDF: {pdf_url}")
-        response = requests.get(pdf_url, timeout=30, stream=True)
-        response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "")
-        if "pdf" not in content_type.lower():
-            print(f"警告: Content-Type 不是 PDF: {content_type}")
-        pdf_content = response.content
-        filename = f"{arxiv_id}.pdf"
-        print(f"成功下载 PDF, 大小: {len(pdf_content)} bytes")
-        return pdf_content, filename
-    except requests.exceptions.RequestException as exc:
-        print(f"下载 arXiv PDF 失败: {exc}")
-        return None
+    """下载 arXiv PDF（优先使用 export.arxiv.org）"""
+    # 优先尝试 export.arxiv.org
+    pdf_urls = [
+        f"https://export.arxiv.org/pdf/{arxiv_id}.pdf",
+        f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+    ]
+
+    for pdf_url in pdf_urls:
+        try:
+            print(f"正在从 arXiv 下载 PDF: {pdf_url}")
+            response = requests.get(pdf_url, timeout=30, stream=True)
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "")
+            if "pdf" not in content_type.lower():
+                print(f"警告: Content-Type 不是 PDF: {content_type}")
+            pdf_content = response.content
+            filename = f"{arxiv_id}.pdf"
+            print(f"成功下载 PDF, 大小: {len(pdf_content)} bytes")
+            return pdf_content, filename
+        except requests.exceptions.RequestException as exc:
+            print(f"从 {pdf_url} 下载失败: {exc}")
+            continue
+
+    print(f"所有 URL 都下载失败")
+    return None
 
 
 def _clean_filename(text: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
This pull request focuses on improving the reliability of downloading arXiv PDFs and updates documentation to remove certain command-line options. The most significant changes are grouped below:

**arXiv PDF Download Logic Improvements:**

* Updated the `_download_arxiv_pdf` function in `update_from_url_route.py` to first attempt downloading PDFs from `export.arxiv.org` before falling back to `arxiv.org`, increasing the chance of successful downloads. Improved error handling now tries all URLs before reporting failure. [[1]](diffhunk://#diff-8f38c27bb41ab3351c980bcddd527f68113d42b90fad6381e23b9fc317950385L59-R66) [[2]](diffhunk://#diff-8f38c27bb41ab3351c980bcddd527f68113d42b90fad6381e23b9fc317950385L72-R82)

**Documentation Updates:**

* Removed the `--max-model-len` and `--gpu-memory-utilization` options from the example `vllm serve` command in both `docs/installation_en.md` and `docs/installation_zh.md` for clarity and accuracy. [[1]](diffhunk://#diff-d63fbd1e4640ba7f13fb72ec8008b4abcba3f7c09289255d92cc49d1118a0eb3L268-L269) [[2]](diffhunk://#diff-35e11dd4b765c00bcf97944213cfa0017edd438b0f832682b37e525437195665L267-L268)